### PR TITLE
Use rust-toolchain.toml instead of rustup default nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-06-15"

--- a/setup/unix.sh
+++ b/setup/unix.sh
@@ -19,7 +19,6 @@ fi
 echo "Adding Teensy Target and llvm-tools-preview"
 rustup target add thumbv7em-none-eabihf
 rustup component add llvm-tools-preview
-rustup default nightly
 
 # Linux Needs libusb-dev
 if type apt-get > /dev/null 2>&1; then


### PR DESCRIPTION
Uses a `rust-toolchain.toml` file instead of `rustup default nightly` so that anytime someone uses cargo or rustup in this project, it will automatically use the nightly channel.