### PR TITLE
[~] Fix setup script, add troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To ensure the correct version of Teensy loader is used by your system ensure the
 
 ## Common Commands
 
+> Run these under the `control/` directory
+
 ### Running main.rs
 
 Kelvin created a runner to make running code on the teensy easier.  To utilize this runner run:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ To open the documentation for internal drivers, libraries, and dependencies run:
 cargo docs --open
 ```
 
+### Troubleshooting
+
+#### \[Linux (maybe MacOS)\] "Unable to claim interface, check USB permissions"
+1. Run:
+> This add you to the `dialout` group, which allows you to access serial communication devices
+```sh
+sudo usermod -a -G dialout $USERNAME
+```
+2. Check if it works. If not, proceed to step 3.
+3. Run:
+> This allows everyone to access USB devices
+```sh
+sudo chmod 777 /dev/bus/usb
+```
+
 ## New Members Project
 
 As you may see, the repository is currently quite bare.  This is due to the rewrite having only started this semester (and a good amount of work and poc testing being done in other repositories).  Therefore, the documentation for a new member project is relatively sparse and probably seems thrown together at the last moment (that's because it is). As much as possible, this tutorial will treat you as though this is your first time seeing Rust and working with a microcontroller; as such, the tutorial will try to relate as many concepts as possible to more common coding langauges like Java. 

--- a/setup/unix.sh
+++ b/setup/unix.sh
@@ -30,4 +30,4 @@ elif type brew > /dev/null 2>&1; then
 fi
 
 # unzip the teensy loader
-unzip "${currentDir}/teensy_loader_cli.zip" -d "${currentDir}/../control/teensy_loader_cli"
+unzip "${currentDir}/setup/teensy_loader_cli.zip" -d "${currentDir}/control"


### PR DESCRIPTION
## Description
Fixes the setup script so it can be run per instructions. Also adds troubleshooting information to the README about common USB permissions errors.
 
## Associated / Resolved Issue
[\~] Fixes the nested `teensy_loader_cli/teensy_loader_cli/...` extraction bug
[\~] Fixes the unzip failure of `setup/unix.sh` when run from project root
[+] Troubleshooting section to `README#Common-Commands` for the "Unable to claim interface, check USB permissions" Teensy Loader error for Linux (and maybe MacOS?)
[+] Note that Teensy commands should be run in `control/` directory

## Design Documents
N/A

## Steps to Test
### Setup Script
1. Run `cd /path/to/robocup-rustware/`
2. Run `./setup/unix.sh`

**Expected result:**
 Run `ls control/teensy-loader-cli`. Output should be: 
```
teensy_loader_cli_linux  teensy_loader_cli_macos  teensy_loader_cli_windows.exe
```

## Key Files to Review
Setup Script
 * `setup/unix.sh`

README
 * `README.md`

## Review Checklist

- [x] **Docstrings**: All methods and classes should have the file appropriate docstrings which follow the guidelines in the ["Contributing" 
page](https://rj-rc-software.readthedocs.io/en/latest/contributing.html) of our docs.
- [x] **Remove extra print statements**: Any print statements used for debugging should be removed
- [x] **Tag reviewers**: Tag some people for review and ping them on Slack