### PR TITLE
Created battery driver; fixes bad branch in previous PR

### DIFF
--- a/control/.vscode/settings.json
+++ b/control/.vscode/settings.json
@@ -10,6 +10,7 @@
     ],
     "rust-analyzer.check.extraArgs": [
         "--bins",
-        "--lib"
+        "--lib",
+        "--examples"
     ]
 }

--- a/control/Cargo.lock
+++ b/control/Cargo.lock
@@ -42,6 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "battery_sense_rs"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal 0.2.7",
+ "imxrt-hal",
+ "teensy4-bsp",
+]
+
+[[package]]
 name = "bbqueue"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +581,7 @@ checksum = "46b71a9d9206e8b46714c74255adcaea8b11e0350c1d8456165073c3f75fc81a"
 name = "robojackets-robocup-control"
 version = "0.2.0"
 dependencies = [
+ "battery_sense_rs",
  "controller",
  "cortex-m",
  "defmt",

--- a/control/Cargo.toml
+++ b/control/Cargo.toml
@@ -18,6 +18,7 @@ embedded-alloc = "0.5.0"
 defmt = "0.3.5"
 libm = "0.2.8"
 fixed-queue = "0.5.1"
+battery_sense_rs = { version = "0.1.0", path = "drivers/battery_sense" }
 
 [dependencies.rtic-nrf24l01]
 git = "https://github.com/N8BWert/rtic-nrf24l01.git"
@@ -98,7 +99,7 @@ members = [
     "drivers/rotary_switch",
     "tools",
     "drivers/kicker-programmer",
-    "drivers/kicker-controller",
+    "drivers/kicker-controller", "drivers/battery_sense",
 ]
 
 # overrides the release build optimization level

--- a/control/drivers/battery_sense/Cargo.toml
+++ b/control/drivers/battery_sense/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "battery_sense_rs"
+version = "0.1.0"
+authors = ["wade-groff <wgroff7@gatech.edu>"]
+edition = "2021"
+
+# always needed for device drivers :)
+[dependencies.embedded-hal]
+version = "~0.2"
+
+[dependencies.teensy4-bsp]
+version = "0.4"
+
+[dependencies.imxrt-hal]
+version = "=0.5.4"
+features = ["eh02-unproven"]

--- a/control/drivers/battery_sense/src/error.rs
+++ b/control/drivers/battery_sense/src/error.rs
@@ -1,0 +1,16 @@
+//!
+//! Errors that can occur with the  Battery Driver
+//! 
+
+
+use core::fmt::Debug;
+
+
+// having the generic error type allows us to pass in the actual error type in lib.rs
+#[derive(Debug)]
+/// an error from using the IO Expander
+pub enum BatteryError {
+    
+    /// error directly from the I2C line
+    ADC
+}

--- a/control/drivers/battery_sense/src/error.rs
+++ b/control/drivers/battery_sense/src/error.rs
@@ -1,16 +1,13 @@
 //!
 //! Errors that can occur with the  Battery Driver
-//! 
-
+//!
 
 use core::fmt::Debug;
-
 
 // having the generic error type allows us to pass in the actual error type in lib.rs
 #[derive(Debug)]
 /// an error from using the IO Expander
 pub enum BatteryError {
-    
     /// error directly from the I2C line
-    ADC
+    ADC,
 }

--- a/control/drivers/battery_sense/src/lib.rs
+++ b/control/drivers/battery_sense/src/lib.rs
@@ -1,66 +1,59 @@
-
-//! 
+//!
 //! Driver for reading the battery capacity
-//! 
-
+//!
 
 #![allow(unused_assignments)]
 #![no_std]
 #![crate_type = "lib"]
 #![deny(missing_docs)]
 
-
-
 use core::fmt::Debug;
-use embedded_hal::adc::{OneShot, Channel};
+use embedded_hal::adc::{Channel, OneShot};
 
 // import fpga error type
 pub mod error;
 use error::BatteryError;
 
-
-
 /// Driver for reading Rattery Capacity, returns capacity as a u16
-pub struct BatterySense <AdcT, WordT, PinT, AdcE> where 
-        PinT: Channel<AdcT>,
-        WordT: Into<u16> + From<u16>,
-        AdcT: OneShot<AdcT, WordT, PinT, Error=AdcE>,
-        AdcE: Debug
+pub struct BatterySense<AdcT, WordT, PinT, AdcE>
+where
+    PinT: Channel<AdcT>,
+    WordT: Into<u16> + From<u16>,
+    AdcT: OneShot<AdcT, WordT, PinT, Error = AdcE>,
+    AdcE: Debug,
 {
     adc: AdcT,
     pin: PinT,
     percent_capacity: u16,
-    word: WordT
+    _word: WordT,
 }
 
-
-impl<AdcT, WordT, PinT, AdcE> BatterySense <AdcT, WordT, PinT, AdcE> where 
+impl<AdcT, WordT, PinT, AdcE> BatterySense<AdcT, WordT, PinT, AdcE>
+where
     PinT: Channel<AdcT>,
     WordT: Into<u16> + From<u16>,
-    AdcT: OneShot<AdcT, WordT, PinT, Error=AdcE>,
-    AdcE: Debug
-     {
-
+    AdcT: OneShot<AdcT, WordT, PinT, Error = AdcE>,
+    AdcE: Debug,
+{
     /// creates a new instance of the driver
-    pub fn new( adc: AdcT, pin: PinT) -> Self {
-
+    pub fn new(adc: AdcT, pin: PinT) -> Self {
         let instance = Self {
             adc: adc,
             pin: pin,
             percent_capacity: 0,
-            word: 0.into()
+            _word: 0.into(),
         };
         return instance;
     }
 
     /// Reads the voltage straight from the ADC, converts into real voltage of battery
-    fn read_voltage(&mut self) -> Result<f32,BatteryError> {
+    fn read_voltage(&mut self) -> Result<f32, BatteryError> {
         let raw_in = self.adc.read(&mut self.pin);
         match raw_in {
             // Voltage is given as a range from 0 to 1024, representing 0 to 3V3
             Ok(word) => Ok(((word.into() as f32) * 78. / 10.) / 1024. * 3.3),
-            Err(_) => Err(BatteryError::ADC)
-            }
+            Err(_) => Err(BatteryError::ADC),
+        }
     }
 
     /// Gets the percent capacity using a model we created
@@ -71,5 +64,4 @@ impl<AdcT, WordT, PinT, AdcE> BatterySense <AdcT, WordT, PinT, AdcE> where
         self.percent_capacity = (voltage * 16.37124 - 450.39) as u16;
         Ok(self.percent_capacity)
     }
-
 }

--- a/control/drivers/battery_sense/src/lib.rs
+++ b/control/drivers/battery_sense/src/lib.rs
@@ -60,7 +60,6 @@ where
     pub fn get_percent_capacity(&mut self) -> Result<u16, BatteryError> {
         let voltage = self.read_voltage()?;
         //Ok(voltage)
-        //Ok((-2530. + 232. * voltage - 5.09 * voltage * voltage))
         self.percent_capacity = (voltage * 16.37124 - 450.39) as u16;
         Ok(self.percent_capacity)
     }

--- a/control/drivers/battery_sense/src/lib.rs
+++ b/control/drivers/battery_sense/src/lib.rs
@@ -1,0 +1,75 @@
+
+//! 
+//! Driver for reading the battery capacity
+//! 
+
+
+#![allow(unused_assignments)]
+#![no_std]
+#![crate_type = "lib"]
+#![deny(missing_docs)]
+
+
+
+use core::fmt::Debug;
+use embedded_hal::adc::{OneShot, Channel};
+
+// import fpga error type
+pub mod error;
+use error::BatteryError;
+
+
+
+/// Driver for reading Rattery Capacity, returns capacity as a u16
+pub struct BatterySense <AdcT, WordT, PinT, AdcE> where 
+        PinT: Channel<AdcT>,
+        WordT: Into<u16> + From<u16>,
+        AdcT: OneShot<AdcT, WordT, PinT, Error=AdcE>,
+        AdcE: Debug
+{
+    adc: AdcT,
+    pin: PinT,
+    percent_capacity: u16,
+    word: WordT
+}
+
+
+impl<AdcT, WordT, PinT, AdcE> BatterySense <AdcT, WordT, PinT, AdcE> where 
+    PinT: Channel<AdcT>,
+    WordT: Into<u16> + From<u16>,
+    AdcT: OneShot<AdcT, WordT, PinT, Error=AdcE>,
+    AdcE: Debug
+     {
+
+    /// creates a new instance of the driver
+    pub fn new( adc: AdcT, pin: PinT) -> Self {
+
+        let instance = Self {
+            adc: adc,
+            pin: pin,
+            percent_capacity: 0,
+            word: 0.into()
+        };
+        return instance;
+    }
+
+    /// Reads the voltage straight from the ADC, converts into real voltage of battery
+    fn read_voltage(&mut self) -> Result<f32,BatteryError> {
+        let raw_in = self.adc.read(&mut self.pin);
+        match raw_in {
+            // Voltage is given as a range from 0 to 1024, representing 0 to 3V3
+            Ok(word) => Ok(((word.into() as f32) * 78. / 10.) / 1024. * 3.3),
+            Err(_) => Err(BatteryError::ADC)
+            }
+    }
+
+    /// Gets the percent capacity using a model we created
+    pub fn get_percent_capacity(&mut self) -> Result<u16, BatteryError> {
+        let voltage = self.read_voltage()?;
+        //Ok(voltage)
+        //Ok((-2530. + 232. * voltage - 5.09 * voltage * voltage))
+        self.percent_capacity = (voltage * 16.37124 - 450.39) as u16;
+        Ok(self.percent_capacity)
+    }
+
+}

--- a/control/drivers/battery_sense/src/lib.rs
+++ b/control/drivers/battery_sense/src/lib.rs
@@ -59,7 +59,6 @@ where
     /// Gets the percent capacity using a model we created
     pub fn get_percent_capacity(&mut self) -> Result<u16, BatteryError> {
         let voltage = self.read_voltage()?;
-        //Ok(voltage)
         self.percent_capacity = (voltage * 16.37124 - 450.39) as u16;
         Ok(self.percent_capacity)
     }

--- a/control/examples/battery_test.rs
+++ b/control/examples/battery_test.rs
@@ -1,0 +1,118 @@
+//!
+//! Test battery output from ADC and voltage/percent conversion
+//! 
+
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use bsp::board;
+use teensy4_bsp as bsp;
+use teensy4_panic as _;
+
+use imxrt_iomuxc::prelude::*;
+
+use bsp::hal::timer::Blocking;
+
+use rtic::app;
+use rtic_monotonics::systick::*;
+
+use battery_sense_rs as battery_sense;
+use battery_sense::BatterySense;
+
+
+
+
+use embedded_alloc::Heap;
+use teensy4_pins::t41::*;
+use bsp::hal::adc::AnalogInput;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+#[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [GPIO1_INT0, GPIO1_INT1])]
+mod app {
+    use core::convert::Infallible;
+
+    // this allows us to define our packages outside the app module
+    // we're essetially "bringing them all in"
+    use super::*;
+
+    // Pin with ADC for initial measurement
+
+    // accounts for our syst_clock to be in 10 kHz (normal is 1 kHz)
+    // this means that the granularity for the delay is 0.1 ms per tick
+    // therefore we multiply our delay time by a factor of 10
+    const SYST_MONO_FACTOR: u32 = 10;
+
+    use robojackets_robocup_control::peripherals::BatterySenseT;
+
+    #[local]
+    struct Local {
+        battery_sensor: BatterySenseT,
+    }
+
+    #[shared]
+    struct Shared {
+        battery_capacity: u16,
+    }
+
+    #[init]
+    fn init(cx: init::Context) -> (Shared, Local) {
+        let board::Resources {
+            mut pins,
+            mut usb,
+            mut adc1,
+            ..
+        } = board::t41(cx.device);
+
+        bsp::LoggingFrontend::default_log().register_usb(usb);
+
+        let systick_token = rtic_monotonics::create_systick_token!();
+        Systick::start(cx.core.SYST, 36_000_000, systick_token);
+
+        // TODO change the pin input to be an analog input
+        let p41_input = bsp::hal::adc::AnalogInput::new(pins.p41);
+        let battery_sensor = BatterySenseT::new( adc1, p41_input);
+        let current_capacity = 0;
+
+        get_battery_capacity::spawn().ok();
+        (
+            Shared {
+                battery_capacity: current_capacity,
+            },
+            Local {
+                battery_sensor: battery_sensor,
+            }
+        )
+    }
+
+    // (optional) lowest priority tasks that runs only while no other task is running
+    #[idle]
+    fn idle(_: idle::Context) -> !{
+        loop {
+            // wfi: wait-for-interrupt
+            cortex_m::asm::wfi();
+        }
+    }
+
+    #[task(priority=1, shared = [battery_capacity], local = [battery_sensor])]
+    async fn get_battery_capacity(mut cx: get_battery_capacity::Context) {
+        let mut capacity = cx.local.battery_sensor.get_percent_capacity().expect("Invalid response for get_percent_capacity");
+        cx.shared.battery_capacity.lock(| battery_capacity | {
+            *battery_capacity = capacity;
+        });
+
+        log::info!("Battreee capacity: {:?}", capacity);
+
+        battery_dly::spawn().ok();
+    }
+
+    #[task(priority = 1)]
+    async fn battery_dly(_cx: battery_dly::Context) {
+        Systick::delay(25000000.micros()).await;
+        get_battery_capacity::spawn().ok();
+    }
+
+
+}

--- a/control/examples/battery_test.rs
+++ b/control/examples/battery_test.rs
@@ -1,6 +1,6 @@
 //!
 //! Test battery output from ADC and voltage/percent conversion
-//! 
+//!
 
 #![no_std]
 #![no_main]
@@ -10,40 +10,18 @@ use bsp::board;
 use teensy4_bsp as bsp;
 use teensy4_panic as _;
 
-use imxrt_iomuxc::prelude::*;
-
-use bsp::hal::timer::Blocking;
-
-use rtic::app;
 use rtic_monotonics::systick::*;
 
-use battery_sense_rs as battery_sense;
-use battery_sense::BatterySense;
-
-
-
-
 use embedded_alloc::Heap;
-use teensy4_pins::t41::*;
-use bsp::hal::adc::AnalogInput;
 
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
 
 #[rtic::app(device = teensy4_bsp, peripherals = true, dispatchers = [GPIO1_INT0, GPIO1_INT1])]
 mod app {
-    use core::convert::Infallible;
-
     // this allows us to define our packages outside the app module
     // we're essetially "bringing them all in"
     use super::*;
-
-    // Pin with ADC for initial measurement
-
-    // accounts for our syst_clock to be in 10 kHz (normal is 1 kHz)
-    // this means that the granularity for the delay is 0.1 ms per tick
-    // therefore we multiply our delay time by a factor of 10
-    const SYST_MONO_FACTOR: u32 = 10;
 
     use robojackets_robocup_control::peripherals::BatterySenseT;
 
@@ -60,10 +38,7 @@ mod app {
     #[init]
     fn init(cx: init::Context) -> (Shared, Local) {
         let board::Resources {
-            mut pins,
-            mut usb,
-            mut adc1,
-            ..
+            pins, usb, adc1, ..
         } = board::t41(cx.device);
 
         bsp::LoggingFrontend::default_log().register_usb(usb);
@@ -73,7 +48,7 @@ mod app {
 
         // TODO change the pin input to be an analog input
         let p41_input = bsp::hal::adc::AnalogInput::new(pins.p41);
-        let battery_sensor = BatterySenseT::new( adc1, p41_input);
+        let battery_sensor = BatterySenseT::new(adc1, p41_input);
         let current_capacity = 0;
 
         get_battery_capacity::spawn().ok();
@@ -81,15 +56,13 @@ mod app {
             Shared {
                 battery_capacity: current_capacity,
             },
-            Local {
-                battery_sensor: battery_sensor,
-            }
+            Local { battery_sensor },
         )
     }
 
     // (optional) lowest priority tasks that runs only while no other task is running
     #[idle]
-    fn idle(_: idle::Context) -> !{
+    fn idle(_: idle::Context) -> ! {
         loop {
             // wfi: wait-for-interrupt
             cortex_m::asm::wfi();
@@ -98,8 +71,12 @@ mod app {
 
     #[task(priority=1, shared = [battery_capacity], local = [battery_sensor])]
     async fn get_battery_capacity(mut cx: get_battery_capacity::Context) {
-        let mut capacity = cx.local.battery_sensor.get_percent_capacity().expect("Invalid response for get_percent_capacity");
-        cx.shared.battery_capacity.lock(| battery_capacity | {
+        let capacity = cx
+            .local
+            .battery_sensor
+            .get_percent_capacity()
+            .expect("Invalid response for get_percent_capacity");
+        cx.shared.battery_capacity.lock(|battery_capacity| {
             *battery_capacity = capacity;
         });
 
@@ -113,6 +90,4 @@ mod app {
         Systick::delay(25000000.micros()).await;
         get_battery_capacity::spawn().ok();
     }
-
-
 }

--- a/control/src/peripherals.rs
+++ b/control/src/peripherals.rs
@@ -15,13 +15,16 @@ use teensy4_bsp::hal::{
     lpspi::{Lpspi, LpspiError},
     pit::Pit2,
     timer::Blocking,
+    adc::AnalogInput,
 };
 
 use fpga_rs::FPGA;
 use icm42605_driver::IMU;
 use io_expander_rs::IoExpander;
+use battery_sense_rs::BatterySense;
 use kicker_programmer::KickerProgrammer;
 use rotary_switch_rs::RotarySwitch;
+use imxrt_hal::adc::Adc;
 
 use super::GPT_FREQUENCY;
 
@@ -68,3 +71,11 @@ pub type KickerReset = Output<P6>;
 pub type KickerCSn = Output<P5>;
 /// The Kicker Programmer
 pub type KickerProg = KickerProgrammer<KickerCSn, KickerReset>;
+
+// Adc Port used by BatterySense
+pub type AdcP = AnalogInput<P41, 1>;
+
+/// One of two ADCs defined under Teensy 4.1 docs
+pub type Adc1 = Adc<1>;
+// Alias of BatterySense
+pub type BatterySenseT = BatterySense<Adc1, u16, AdcP, Infallible>;

--- a/control/src/peripherals.rs
+++ b/control/src/peripherals.rs
@@ -10,21 +10,21 @@ use teensy4_pins::t41::*;
 
 use teensy4_bsp::board::{self, Lpi2c1, Lpi2c3, PERCLK_FREQUENCY};
 use teensy4_bsp::hal::{
+    adc::AnalogInput,
     gpio::{Input, Output, Port},
     gpt::{Gpt1, Gpt2},
     lpspi::{Lpspi, LpspiError},
     pit::Pit2,
     timer::Blocking,
-    adc::AnalogInput,
 };
 
+use battery_sense_rs::BatterySense;
 use fpga_rs::FPGA;
 use icm42605_driver::IMU;
+use imxrt_hal::adc::Adc;
 use io_expander_rs::IoExpander;
-use battery_sense_rs::BatterySense;
 use kicker_programmer::KickerProgrammer;
 use rotary_switch_rs::RotarySwitch;
-use imxrt_hal::adc::Adc;
 
 use super::GPT_FREQUENCY;
 


### PR DESCRIPTION
Description
Adding the battery sense driver. Takes in a voltage reading from the ADC, then calculates the percentage based on a model we created. Accurate from around 60-100 percent.

Build and run battery_test.rs on a robot to test this. Pin 41 is used as the analog input for this purpose.

Note: Wade Groff and James Vogt contributed to this code; Since this is a duplicate branch, the authors are not properly tracked.

Key Files to Review
Group 1

/drivers/battery_sense files
peripherals
examples/battery_test.rs
src/main.rs, added battery reading and logging if below 60 percent
Review Checklist
 Docstrings: All methods and classes should have the file appropriate docstrings which follow the guidelines in the "Contributing"
page of our docs.
 Remove extra print statements: Any print statements used for debugging should be removed
[@N8BWert ] Tag reviewers: Tag some people for review and ping them on Slack