### PR TITLE
Update Unix setup script and add fix for usb permissions error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,23 @@ cargo docs --open
 
 ### Troubleshooting
 
-#### \[Linux (maybe MacOS)\] "Unable to claim interface, check USB permissions"
-1. Run:
-> This add you to the `dialout` group, which allows you to access serial communication devices
+#### \[Linux\] "Unable to claim interface, check USB permissions"
+
+[Original Source](https://www.pjrc.com/teensy/00-teensy.rules)
+
+1. Create a file called `00-teensy.rules` in `/etc/udev/rules.d/` with the following content:
 ```sh
-sudo usermod -a -G dialout $USERNAME
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04[789a]*", ENV{MTP_NO_PROBE}="1"
+KERNEL=="ttyACM*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666", RUN:="/bin/stty -F /dev/%k raw -echo"
+KERNEL=="hidraw*", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="04*", MODE:="0666"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="0666"
 ```
-2. Check if it works. If not, proceed to step 3.
-3. Run:
-> This allows everyone to access USB devices
-```sh
-sudo chmod 777 /dev/bus/usb
-```
+
+2. Disconnect and reconnect the Teensy to your computer.
+
 
 ## New Members Project
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="066
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", ATTRS{idProduct}=="013*", MODE:="0666"
 ```
 
-2. Disconnect and reconnect the Teensy to your computer.
+2. Add yourself to the `dialout` group
+```sh
+sudo usermod -aG dialout [username]
+```
+
+3. Disconnect and reconnect the Teensy to your computer.
+
 
 
 ## New Members Project

--- a/setup/unix.sh
+++ b/setup/unix.sh
@@ -24,10 +24,12 @@ rustup component add llvm-tools-preview
 
 # Linux Needs libusb-dev
 if type apt-get > /dev/null 2>&1; then
+	echo "sudo is required to install required packages"
+	sudo -v
 	sudo apt-get update && sudo apt-get install -y libusb-dev
 elif type brew > /dev/null 2>&1; then
 	brew install libusb libusb-compat
 fi
 
 # unzip the teensy loader
-unzip "${currentDir}/setup/teensy_loader_cli.zip" -d "${currentDir}/control"
+unzip -o "${currentDir}/setup/teensy_loader_cli.zip" -d "${currentDir}/control"

--- a/setup/unix.sh
+++ b/setup/unix.sh
@@ -24,7 +24,7 @@ rustup component add llvm-tools-preview
 
 # Linux Needs libusb-dev
 if type apt-get > /dev/null 2>&1; then
-	sudo apt-get update && apt-get install -y libusb-dev
+	sudo apt-get update && sudo apt-get install -y libusb-dev
 elif type brew > /dev/null 2>&1; then
 	brew install libusb libusb-compat
 fi


### PR DESCRIPTION
- Updates the Unix setup script to fix an apt permissions issue.
- Sets unzip to default replace existing files, so user doesn't have to manually approve overriding each file
- Provides a permanent fix to the "Unable to claim interface, check USB permissions" error while uploading